### PR TITLE
Include specifications for Ruby 2.x scls

### DIFF
--- a/ruby.yml
+++ b/ruby.yml
@@ -1,0 +1,16 @@
+# Recipes for Ruby Software Collections
+---
+ruby200:
+  - name: Ruby 2.0.0
+  - packages:
+    - ruby200
+    - ruby
+
+rh-ruby22:
+  - name: Ruby 2.2
+  - packages:
+    - rh-ruby22
+    - ruby
+    - rubygem-net-http-persistent
+    - rubygem-thor
+    - rubygem-bundler


### PR DESCRIPTION
Ruby 1.9.3 includes Rails packages and I am unsure about the order ATM so including specs for Ruby 2.x.
