### PR TITLE
Add MongoDB python27 requires

### DIFF
--- a/mongodb.yml
+++ b/mongodb.yml
@@ -15,7 +15,7 @@ mongodb24:
 
 rh-mongodb26:
   name: MongoDB 2.6
-  requires: [rh-java-common, maven30, v3814]
+  requires: [rh-java-common, maven30, v3814, python27]
   packages:
     - rh-mongodb26
     - scons


### PR DESCRIPTION
I've forgotten to include python27 requires. Because rh-mongodb26-mongodb build-requires python27-python-pymongo (to run test suite).
