### PR TITLE
Add recipe for thermostat1 scl.

### DIFF
--- a/thermostat.yml
+++ b/thermostat.yml
@@ -1,0 +1,14 @@
+# Recipe for thermostat1 collection
+---
+thermostat1:
+  name: Thermostat 1.2
+  requires: [rh-java-common, rh-mongodb26]
+  packages:
+    - thermostat1
+    - protobuf-java
+    - netty
+    - jcommon
+    - jfreechart
+    - jline2
+    - apache-commons-fileupload
+    - thermostat


### PR DESCRIPTION
Note that protobuf-java is a BR of netty and I'm not aware of any
source RPM release other than this one:

https://www.softwarecollections.org/repos/rhscl/thermostat1/epel-7-x86_64/thermostat1-protobuf-java-2.5.0-5.el7.centos.src.rpm

Instructions as to how to build the collection are:
1. Install dependent scldevel packages + javapackages-tools:
   $ yum install rh-mongodb26-scldevel \
                rh-java-common-scldevel \
                maven30-scldevel \
                maven30-javapackages-tools
2. Build metapackage: thermostat1
3. Build other packages as listed in yaml file.
