### PR TITLE
Add cmd element to hack bootstrapping logic in rubygem-flexmock.spec

### DIFF
--- a/ror.yml
+++ b/ror.yml
@@ -36,6 +36,10 @@ rh-ror50:
     - rubygem-flexmock:
         macros:
           _with_bootstrap: 1
+        cmd:
+          # Hack around flexmock bootstrap
+          - sed -i '/^BuildRequires.*rubygem(rspec)$/ s/^/#/' rubygem-flexmock.spec
+          - sed -i '/^%check$/,/^popd$/ s/^/#/' rubygem-flexmock.spec
     - rubygem-metaclass
     - rubygem-builder
     - rubygem-introspection


### PR DESCRIPTION
Because we `cmd` element in a recipe file was implemented.
https://github.com/sclorg/rpm-list-builder/commit/6061c2adffdbaa36a5ba3aec638448fbe0b726bb
