### PR TITLE
Keep platforms element as deprecated status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ COLLECTION_ID_A:
         ...
         - COMMAND_N
       dist: DIST_RE
+      platforms:
+        - PLATFORM_1
+        - PLATFORM_2
+        ...
+        - PLATFORM_N
       patch: PATCH_CONTENT
     - PACKAGE_3
     ...
@@ -67,6 +72,7 @@ COLLECTION_ID_B:
 | `COLLECTION_ID/packages/PACKAGE/cmd` | Not recommended. But if `macros` and `replaced_macros` are not enough for your requirement, you can use it. For example `sed -i 'something' foo.spec` to edit RPM spec file. | Union (Scalar or Sequences) | No | Yes |
 | `COLLECTION_ID/packages/PACKAGE/dist` | Distribution platforms that are considered to build. The format is a regular expression. A `platforms` element was changed to this element. Use `dist` instead of `platforms` element. | Scalar | No | Yes |
 | `COLLECTION_ID/packages/PACKAGE/patch` | Deprecated, due to that it can be replaced as `macros`, `replaced_macros`, or `cmd` element. | Scalar | No | No |
+| `COLLECTION_ID/packages/PACKAGE/platforms` | Deprecated, due to that it can be replaced as `dist` element. Set of platforms that are considered to build. | Sequences | No | No |
 
 **Caution**: "Supported?" column means whether the element is supported by the tool to parse the recipe file and build automatically: [RPM List Builder](https://github.com/sclorg/rpm-list-builder).
   If the element is Supported?: No, the status is only proposed. It can be chnaged in the future.


### PR DESCRIPTION
I would keep platforms element as deprecated status in our document, just in case.

Modified README is here.
https://github.com/junaruga/rhscl-rebuild-recipes/blob/feature/add-platforms-element/README.md

If you have a request to implement `platforms` element, please report us.
Thank you.
